### PR TITLE
skip packages without version information

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ A simple measure of dependency freshness
 
 Calculates the total number of years behind their respective newest versions for all dependencies listed in `composer.json`.
 
+## Requirements
+
+- PHP 7.4 or later 
+
 ## Installation
 
 Simply download `libyear.phar` from the latest release.


### PR DESCRIPTION
There are packages that don't have proper version information. Here is an example of a package that only has a `dev-master` version: https://packagist.org/packages/lorb/collection-statistics

In this case `$sorted_versions` is an empty array which leads to a crash later on. Such packages can be skipped with the change in this PR.