### PR TITLE
fix: php parse error

### DIFF
--- a/src/PackagistAPI.php
+++ b/src/PackagistAPI.php
@@ -7,30 +7,30 @@ use GuzzleHttp\Exception\GuzzleException;
 
 class PackagistAPI
 {
-	private ClientInterface $http_client;
+    private ClientInterface $http_client;
 
-	/** @var resource */
-	private $stderr;
+    /** @var resource */
+    private $stderr;
 
-	/**
-	 * @param ClientInterface $http_client
-	 * @param resource $stderr
-	 */
-	public function __construct(ClientInterface $http_client, $stderr)
-	{
-		$this->http_client = $http_client;
-		$this->stderr = $stderr;
-	}
+    /**
+     * @param resource $stderr
+     */
+    public function __construct(ClientInterface $http_client, $stderr)
+    {
+        $this->http_client = $http_client;
+        $this->stderr = $stderr;
+    }
 
-	public function getPackageInfo(string $package): array
-	{
-		try {
-			$response = $this->http_client->request('GET', "https://repo.packagist.org/packages/{$package}.json");
-			return json_decode($response->getBody()->getContents(), true) ?? [];
+    public function getPackageInfo(string $package): array
+    {
+        try {
+            $response = $this->http_client->request('GET', "https://repo.packagist.org/packages/{$package}.json");
 
-		} catch (GuzzleException) {
-			fwrite($this->stderr, "Could not find info for {$package} on Packagist\n");
-			return [];
-		}
-	}
+            return json_decode($response->getBody()->getContents(), true) ?? [];
+        } catch (GuzzleException $e) {
+            fwrite($this->stderr, "Could not find info for {$package} on Packagist\n");
+
+            return [];
+        }
+    }
 }

--- a/src/PackagistAPI.php
+++ b/src/PackagistAPI.php
@@ -7,30 +7,30 @@ use GuzzleHttp\Exception\GuzzleException;
 
 class PackagistAPI
 {
-    private ClientInterface $http_client;
+	private ClientInterface $http_client;
 
-    /** @var resource */
-    private $stderr;
+	/** @var resource */
+	private $stderr;
 
-    /**
-     * @param resource $stderr
-     */
-    public function __construct(ClientInterface $http_client, $stderr)
-    {
-        $this->http_client = $http_client;
-        $this->stderr = $stderr;
-    }
+	/**
+	 * @param ClientInterface $http_client
+	 * @param resource $stderr
+	 */
+	public function __construct(ClientInterface $http_client, $stderr)
+	{
+		$this->http_client = $http_client;
+		$this->stderr = $stderr;
+	}
 
-    public function getPackageInfo(string $package): array
-    {
-        try {
-            $response = $this->http_client->request('GET', "https://repo.packagist.org/packages/{$package}.json");
+	public function getPackageInfo(string $package): array
+	{
+		try {
+			$response = $this->http_client->request('GET', "https://repo.packagist.org/packages/{$package}.json");
+			return json_decode($response->getBody()->getContents(), true) ?? [];
 
-            return json_decode($response->getBody()->getContents(), true) ?? [];
-        } catch (GuzzleException $e) {
-            fwrite($this->stderr, "Could not find info for {$package} on Packagist\n");
-
-            return [];
-        }
-    }
+		} catch (GuzzleException $e) {
+			fwrite($this->stderr, "Could not find info for {$package} on Packagist\n");
+			return [];
+		}
+	}
 }


### PR DESCRIPTION
PHP  parse error when run on version. php7.4

```php
PHP Parse error:  syntax error, unexpected ')', expecting '|' or variable (T_VARIABLE) in vendor/ecoapm/libyear/src/PackagistAPI.php on line 30
```