### PR TITLE
fix: php parse error

### DIFF
--- a/src/PackagistAPI.php
+++ b/src/PackagistAPI.php
@@ -27,7 +27,7 @@ class PackagistAPI
 		try {
 			$response = $this->http_client->request('GET', "https://repo.packagist.org/packages/{$package}.json");
 			return json_decode($response->getBody()->getContents(), true) ?? [];
-        } catch (GuzzleException $e) {
+		} catch (GuzzleException $e) {
 			fwrite($this->stderr, "Could not find info for {$package} on Packagist\n");
 			return [];
 		}

--- a/src/PackagistAPI.php
+++ b/src/PackagistAPI.php
@@ -28,6 +28,7 @@ class PackagistAPI
 			$response = $this->http_client->request('GET', "https://repo.packagist.org/packages/{$package}.json");
 			return json_decode($response->getBody()->getContents(), true) ?? [];
         } catch (GuzzleException $e) {
+			fwrite($this->stderr, "Could not find info for {$package} on Packagist\n");
 			return [];
 		}
 	}

--- a/src/PackagistAPI.php
+++ b/src/PackagistAPI.php
@@ -27,9 +27,7 @@ class PackagistAPI
 		try {
 			$response = $this->http_client->request('GET', "https://repo.packagist.org/packages/{$package}.json");
 			return json_decode($response->getBody()->getContents(), true) ?? [];
-
-		} catch (GuzzleException) {
-			fwrite($this->stderr, "Could not find info for {$package} on Packagist\n");
+        } catch (GuzzleException $e) {
 			return [];
 		}
 	}


### PR DESCRIPTION
PHP parse error when run on version. php7.4

```php
PHP Parse error:  syntax error, unexpected ')', expecting '|' or variable (T_VARIABLE) in vendor/ecoapm/libyear/src/PackagistAPI.php on line 30
```