### PR TITLE
Test up to PHP 8.4

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ '8.1', '8.2' ]
+        version: [ '8.1', '8.2', '8.3', '8.4' ]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Currently, this package only tests against PHP 8.1 and 8.2. However, the latest PHP version is 8.4 and 8.5 is coming later this year. This PR adds testing against PHP 8.3 and 8.4 to make sure all current PHP versions are tested against.