### PR TITLE
Use current Packagist v2 API endpoints instead of the now defunct v1 API endpoints.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,13 @@
     "require": {
         "php": ">=8.1",
         "ext-json": ">=8.1",
-        "composer/semver": "3.4.3",
-        "guzzlehttp/guzzle": "7.9.3",
+        "composer/semver": "3.4.4",
+        "guzzlehttp/guzzle": "7.10.0",
         "vanilla/garden-cli": "v4.0",
         "wp-cli/php-cli-tools": "v0.12.5"
     },
     "require-dev": {
-        "phpunit/phpunit": "10.5.44",
+        "phpunit/phpunit": "10.5.47",
         "mockery/mockery": "1.6.12"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0222269c53199f3f3b0c1d0b3627a8e9",
+    "content-hash": "073440eeaf37490cfc8f775206fd5195",
     "packages": [
         {
             "name": "composer/semver",
-            "version": "3.4.3",
+            "version": "3.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/semver.git",
-                "reference": "4313d26ada5e0c4edfbd1dc481a92ff7bff91f12"
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/4313d26ada5e0c4edfbd1dc481a92ff7bff91f12",
-                "reference": "4313d26ada5e0c4edfbd1dc481a92ff7bff91f12",
+                "url": "https://api.github.com/repos/composer/semver/zipball/198166618906cb2de69b95d7d47e5fa8aa1b2b95",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95",
                 "shasum": ""
             },
             "require": {
@@ -69,7 +69,7 @@
             "support": {
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/3.4.3"
+                "source": "https://github.com/composer/semver/tree/3.4.4"
             },
             "funding": [
                 {
@@ -79,32 +79,28 @@
                 {
                     "url": "https://github.com/composer",
                     "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2024-09-19T14:15:21+00:00"
+            "time": "2025-08-20T19:15:30+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.9.3",
+            "version": "7.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "7b2f29fe81dc4da0ca0ea7d42107a0845946ea77"
+                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/7b2f29fe81dc4da0ca0ea7d42107a0845946ea77",
-                "reference": "7b2f29fe81dc4da0ca0ea7d42107a0845946ea77",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
+                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^1.5.3 || ^2.0.3",
-                "guzzlehttp/psr7": "^2.7.0",
+                "guzzlehttp/promises": "^2.3",
+                "guzzlehttp/psr7": "^2.8",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
                 "symfony/deprecation-contracts": "^2.2 || ^3.0"
@@ -195,7 +191,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.9.3"
+                "source": "https://github.com/guzzle/guzzle/tree/7.10.0"
             },
             "funding": [
                 {
@@ -211,20 +207,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-27T13:37:11+00:00"
+            "time": "2025-08-23T22:36:01+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.2.0",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "7c69f28996b0a6920945dd20b3857e499d9ca96c"
+                "reference": "481557b130ef3790cf82b713667b43030dc9c957"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/7c69f28996b0a6920945dd20b3857e499d9ca96c",
-                "reference": "7c69f28996b0a6920945dd20b3857e499d9ca96c",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/481557b130ef3790cf82b713667b43030dc9c957",
+                "reference": "481557b130ef3790cf82b713667b43030dc9c957",
                 "shasum": ""
             },
             "require": {
@@ -232,7 +228,7 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.39 || ^9.6.20"
+                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
             },
             "type": "library",
             "extra": {
@@ -278,7 +274,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.2.0"
+                "source": "https://github.com/guzzle/promises/tree/2.3.0"
             },
             "funding": [
                 {
@@ -294,20 +290,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-27T13:27:01+00:00"
+            "time": "2025-08-22T14:34:08+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.7.1",
+            "version": "2.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "c2270caaabe631b3b44c85f99e5a04bbb8060d16"
+                "reference": "21dc724a0583619cd1652f673303492272778051"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/c2270caaabe631b3b44c85f99e5a04bbb8060d16",
-                "reference": "c2270caaabe631b3b44c85f99e5a04bbb8060d16",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/21dc724a0583619cd1652f673303492272778051",
+                "reference": "21dc724a0583619cd1652f673303492272778051",
                 "shasum": ""
             },
             "require": {
@@ -323,7 +319,7 @@
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "http-interop/http-factory-tests": "0.9.0",
-                "phpunit/phpunit": "^8.5.39 || ^9.6.20"
+                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
@@ -394,7 +390,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.7.1"
+                "source": "https://github.com/guzzle/psr7/tree/2.8.0"
             },
             "funding": [
                 {
@@ -410,7 +406,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-27T12:30:47+00:00"
+            "time": "2025-08-23T21:21:41+00:00"
         },
         {
             "name": "psr/http-client",
@@ -574,16 +570,16 @@
         },
         {
             "name": "psr/log",
-            "version": "3.0.0",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001"
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/fe5ea303b0887d5caefd3d431c3e61ad47037001",
-                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
                 "shasum": ""
             },
             "require": {
@@ -618,9 +614,9 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/3.0.0"
+                "source": "https://github.com/php-fig/log/tree/3.0.2"
             },
-            "time": "2021-07-14T16:46:02+00:00"
+            "time": "2024-09-11T13:17:53+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -668,16 +664,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.5.1",
+            "version": "v3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6"
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6",
-                "reference": "74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
                 "shasum": ""
             },
             "require": {
@@ -690,7 +686,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.5-dev"
+                    "dev-main": "3.6-dev"
                 }
             },
             "autoload": {
@@ -715,7 +711,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.5.1"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
             },
             "funding": [
                 {
@@ -731,7 +727,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:20:29+00:00"
+            "time": "2024-09-25T14:21:43+00:00"
         },
         {
             "name": "vanilla/garden-cli",
@@ -855,20 +851,20 @@
     "packages-dev": [
         {
             "name": "hamcrest/hamcrest-php",
-            "version": "v2.0.1",
+            "version": "v2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hamcrest/hamcrest-php.git",
-                "reference": "8c3d0a3f6af734494ad8f6fbbee0ba92422859f3"
+                "reference": "f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/8c3d0a3f6af734494ad8f6fbbee0ba92422859f3",
-                "reference": "8c3d0a3f6af734494ad8f6fbbee0ba92422859f3",
+                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487",
+                "reference": "f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3|^7.0|^8.0"
+                "php": "^7.4|^8.0"
             },
             "replace": {
                 "cordoval/hamcrest-php": "*",
@@ -876,8 +872,8 @@
                 "kodova/hamcrest-php": "*"
             },
             "require-dev": {
-                "phpunit/php-file-iterator": "^1.4 || ^2.0",
-                "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0"
+                "phpunit/php-file-iterator": "^1.4 || ^2.0 || ^3.0",
+                "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0 || ^8.0 || ^9.0"
             },
             "type": "library",
             "extra": {
@@ -900,9 +896,9 @@
             ],
             "support": {
                 "issues": "https://github.com/hamcrest/hamcrest-php/issues",
-                "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.0.1"
+                "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.1.1"
             },
-            "time": "2020-07-09T08:09:16+00:00"
+            "time": "2025-04-30T06:54:44+00:00"
         },
         {
             "name": "mockery/mockery",
@@ -989,16 +985,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.12.1",
+            "version": "1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "123267b2c49fbf30d78a7b2d333f6be754b94845"
+                "reference": "1720ddd719e16cf0db4eb1c6eca108031636d46c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/123267b2c49fbf30d78a7b2d333f6be754b94845",
-                "reference": "123267b2c49fbf30d78a7b2d333f6be754b94845",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/1720ddd719e16cf0db4eb1c6eca108031636d46c",
+                "reference": "1720ddd719e16cf0db4eb1c6eca108031636d46c",
                 "shasum": ""
             },
             "require": {
@@ -1037,7 +1033,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.12.1"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.1"
             },
             "funding": [
                 {
@@ -1045,20 +1041,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-08T17:47:46+00:00"
+            "time": "2025-04-29T12:36:36+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.4.0",
+            "version": "v5.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "447a020a1f875a434d62f2a401f53b82a396e494"
+                "reference": "ae59794362fe85e051a58ad36b289443f57be7a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/447a020a1f875a434d62f2a401f53b82a396e494",
-                "reference": "447a020a1f875a434d62f2a401f53b82a396e494",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/ae59794362fe85e051a58ad36b289443f57be7a9",
+                "reference": "ae59794362fe85e051a58ad36b289443f57be7a9",
                 "shasum": ""
             },
             "require": {
@@ -1101,9 +1097,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.4.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.5.0"
             },
-            "time": "2024-12-30T11:07:19+00:00"
+            "time": "2025-05-31T08:24:38+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -1546,16 +1542,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.44",
+            "version": "10.5.47",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "1381c62769be4bb88fa4c5aec1366c7c66ca4f36"
+                "reference": "3637b3e50d32ab3a0d1a33b3b6177169ec3d95a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/1381c62769be4bb88fa4c5aec1366c7c66ca4f36",
-                "reference": "1381c62769be4bb88fa4c5aec1366c7c66ca4f36",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3637b3e50d32ab3a0d1a33b3b6177169ec3d95a3",
+                "reference": "3637b3e50d32ab3a0d1a33b3b6177169ec3d95a3",
                 "shasum": ""
             },
             "require": {
@@ -1565,7 +1561,7 @@
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.12.1",
+                "myclabs/deep-copy": "^1.13.1",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.1",
@@ -1627,7 +1623,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.44"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.47"
             },
             "funding": [
                 {
@@ -1639,11 +1635,19 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-01-31T07:00:38+00:00"
+            "time": "2025-06-20T11:29:11+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -2614,13 +2618,13 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": ">=8.1",
         "ext-json": ">=8.1"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }

--- a/src/Calculator.php
+++ b/src/Calculator.php
@@ -76,14 +76,16 @@ class Calculator
 	}
 
 	/**
-	 * @param array $releases
+	 * @param array $package_data
 	 * @return DateTimeInterface[]
 	 */
-	private static function getVersions(array $releases): array
+	private static function getVersions(array $package_data): array
 	{
 		$versions = [];
-		foreach ($releases as $release) {
-			$versions[$release['version']] = self::findReleaseDate($release);
+		if (isset($package_data['versions'])) {
+			foreach ($package_data['versions'] as $version => $version_data) {
+				$versions[$version] = self::findReleaseDate($version_data);
+			}
 		}
 		return array_filter($versions);
 	}

--- a/src/ComposerFile.php
+++ b/src/ComposerFile.php
@@ -4,7 +4,7 @@ namespace ecoAPM\LibYear;
 
 class ComposerFile
 {
-	const DEFAULT_URL = 'https://repo.packagist.org';
+	const DEFAULT_URL = 'https://packagist.org';
 
 	private FileSystem $file_system;
 

--- a/src/RepositoryAPI.php
+++ b/src/RepositoryAPI.php
@@ -27,6 +27,12 @@ class RepositoryAPI
 		try {
 			$response = $this->http_client->request('GET', "$url/packages.json");
 			$result = json_decode($response->getBody()->getContents(), true) ?? [];
+			
+			// For the new packagist.org, override the deprecated metadata-url 
+			if ($url === 'https://packagist.org') {
+				return new Repository($url, '/packages/%package%.json');
+			}
+			
 			return new Repository($url, array_key_exists('metadata-url', $result) ? $result['metadata-url'] : null);
 		} catch (GuzzleException $e) {
 			if ($verbose) {
@@ -42,7 +48,7 @@ class RepositoryAPI
 			$url = $repository->getMetadataURL($package);
 			$response = $this->http_client->request('GET', $url);
 			$json = json_decode($response->getBody()->getContents(), true);
-			return $json['packages'][$package] ?? [];
+			return $json['package'] ?? [];
 		} catch (GuzzleException $e) {
 			if ($verbose) {
 				fwrite($this->stderr, "Could not find info for $package on $repository->url\n");

--- a/tests/CalculatorTest.php
+++ b/tests/CalculatorTest.php
@@ -20,7 +20,7 @@ class CalculatorTest extends TestCase
 	public function testCanFillOutDependencyInfo()
 	{
 		//arrange
-		$repository = new Repository('https://repo.packagist.org', '/p2/%package%.json');
+		$repository = new Repository('https://packagist.org', '/packages/%package%.json');
 		$dependency = new Dependency('vendor_name/package_name', '1.2.3');
 		$composer = Mockery::mock(ComposerFile::class, [
 			'getRepositories' => [$repository->url],
@@ -30,8 +30,10 @@ class CalculatorTest extends TestCase
 		$api = Mockery::mock(RepositoryAPI::class, [
 			'getInfo' => $repository,
 			'getPackageInfo' => [
-				['version' => '1.2.3', 'time' => '2018-07-01'],
-				['version' => '2.3.4', 'extra' => ['drupal' => ['datestamp' => '1577836800']]]
+				'versions' => [
+					'1.2.3' => ['time' => '2018-07-01'],
+					'2.3.4' => ['extra' => ['drupal' => ['datestamp' => '1577836800']]]
+				]
 			]
 		]);
 		$progress = Mockery::mock(Progress::class, [
@@ -65,7 +67,7 @@ class CalculatorTest extends TestCase
 		$api = Mockery::mock(RepositoryAPI::class);
 		$api->shouldReceive('getPackageInfo')->andReturn(
 			[
-				['version' => '1.2.4', 'time' => '2018-07-01']
+				'versions' => ['1.2.4' => ['time' => '2018-07-01']]
 			],
 			[
 				[]
@@ -101,7 +103,7 @@ class CalculatorTest extends TestCase
 
 		$api = Mockery::mock(RepositoryAPI::class, [
 			'getPackageInfo' => [
-				['version' => '1.2.4', 'time' => '2018-07-01']
+				'versions' => ['1.2.4' => ['time' => '2018-07-01']]
 			]
 		]);
 		$repo1 = null;
@@ -172,7 +174,7 @@ class CalculatorTest extends TestCase
 		$api = Mockery::mock(RepositoryAPI::class);
 		$api->shouldReceive('getInfo')->andReturn($repo1, $repo2);
 		$api->shouldReceive('getPackageInfo')->with($dependency->name, $repo1, false)->andReturn([
-			['version' => '1.2.4', 'time' => '2018-07-01']
+			'versions' => ['1.2.4' => ['time' => '2018-07-01']]
 		]);
 		$api->shouldNotReceive('getPackageInfo')->with($dependency->name, $repo2);
 
@@ -207,7 +209,7 @@ class CalculatorTest extends TestCase
 		$api->shouldReceive('getInfo')->andReturn($repo1, $repo2);
 		$api->shouldReceive('getPackageInfo')->with($dependency->name, $repo1, false)->andReturn([]);
 		$api->shouldReceive('getPackageInfo')->with($dependency->name, $repo2, false)->andReturn([
-			['version' => '1.2.4', 'time' => '2018-07-01']
+			'versions' => ['1.2.4' => ['time' => '2018-07-01']]
 		]);
 
 		$progress = Mockery::mock(Progress::class, [

--- a/tests/ComposerFileTest.php
+++ b/tests/ComposerFileTest.php
@@ -27,7 +27,7 @@ class ComposerFileTest extends TestCase
 		$repositories = $composer->getRepositories('.');
 
 		//assert
-		$this->assertEquals(['https://repo.packagist.org'], $repositories);
+		$this->assertEquals(['https://packagist.org'], $repositories);
 	}
 
 	public function testCachesFileSystemResponses()
@@ -88,7 +88,7 @@ class ComposerFileTest extends TestCase
 		$expected = [
 			'https://composer.example.com',
 			'https://composer.example.org',
-			'https://repo.packagist.org'
+			'https://packagist.org'
 		];
 		$this->assertEquals($expected, $repositories);
 	}

--- a/tests/RepositoryAPITest.php
+++ b/tests/RepositoryAPITest.php
@@ -106,15 +106,13 @@ class RepositoryAPITest extends TestCase
 	public function testGetPackageInfoCallsCorrectURL()
 	{
 		//arrange
-		$repo = new Repository('https://repo.packagist.org', '/packages/%package%.json');
+		$repo = new Repository('https://packagist.org', '/packages/%package%.json');
 		$http_client = Mockery::mock(ClientInterface::class, [
 			'request' => Mockery::mock(ResponseInterface::class, [
 				'getStatusCode' => 200,
 				'getBody' => Mockery::mock(StreamInterface::class, [
 					'getContents' => json_encode([
-						'packages' => [
-							'vendor_name/package_name' => []
-						]
+						'package' => []
 					])
 				])
 			])
@@ -128,22 +126,20 @@ class RepositoryAPITest extends TestCase
 
 		//assert
 		$http_client->shouldHaveReceived('request')
-			->with('GET', 'https://repo.packagist.org/packages/vendor_name/package_name.json');
+			->with('GET', 'https://packagist.org/packages/vendor_name/package_name.json');
 	}
 
 	public function testCanGetPackageInfo()
 	{
 		//arrange
-		$repo = new Repository('https://repo.packagist.org', '/packages/%package%.json');
+		$repo = new Repository('https://packagist.org', '/packages/%package%.json');
 		$http_client = Mockery::mock(ClientInterface::class, [
 			'request' => Mockery::mock(ResponseInterface::class, [
 				'getStatusCode' => 200,
 				'getBody' => Mockery::mock(StreamInterface::class, [
 					'getContents' => json_encode([
-						'packages' => [
-							'vendor_name/package_name' => [
-								'test_field' => 'test value'
-							]
+						'package' => [
+							'test_field' => 'test value'
 						]
 					])
 				])
@@ -163,7 +159,7 @@ class RepositoryAPITest extends TestCase
 	public function testGetPackageInfoCanHandleBadResponse()
 	{
 		//arrange
-		$repo = new Repository('https://repo.packagist.org', '/packages/%package%.json');
+		$repo = new Repository('https://packagist.org', '/packages/%package%.json');
 		$http_client = Mockery::mock(ClientInterface::class, [
 			'request' => Mockery::mock(ResponseInterface::class, [
 				'getStatusCode' => 200,
@@ -186,7 +182,7 @@ class RepositoryAPITest extends TestCase
 	public function testPackageInfoIsEmptyOnException()
 	{
 		//arrange
-		$repo = new Repository('https://repo.packagist.org', '/packages/%package%.json');
+		$repo = new Repository('https://packagist.org', '/packages/%package%.json');
 		$http_client = Mockery::mock(ClientInterface::class);
 		$http_client->shouldReceive('request')->andThrow(new ConnectException('', new Request('GET', '')));
 
@@ -207,7 +203,7 @@ class RepositoryAPITest extends TestCase
 	public function testPackageInfoDisplaysErrorInVerboseMode()
 	{
 		//arrange
-		$repo = new Repository('https://repo.packagist.org', '/packages/%package%.json');
+		$repo = new Repository('https://packagist.org', '/packages/%package%.json');
 		$http_client = Mockery::mock(ClientInterface::class);
 		$http_client->shouldReceive('request')->andThrow(new ConnectException('', new Request('GET', '')));
 


### PR DESCRIPTION
## Context

This change is needed because Composer v1 is no longer available as of September 1st, apparently this also means that the Packagist API got cleaned up and some endpoints were removed. It turns out that https://repo.packagist.org is no longer available which was still heavily used in this codebase.

For more info, see https://blog.packagist.com/packagist-org-shutdown-of-composer-1-x-support-postponed-to-september-1st-2025/ for more information on deprecating composer v1.

## What has been done

* Updated the tests to reflect the Packagist v2 API
* Updated the code to deal with the Packagist v2 API
* Tried to keep the codestyle as consistent as possible with the existing codebase without an existing codestyle or linter.

## How to test

#### Broken behaviour:
* Against any repository, run the current released version of php-libyear.
* See that all columns but the current version are empty.
* See that a total of 0.00 libyears is calculated.

#### Fixed behaviour:
* Against any repository, run the version of php-libyear from this PR.
* See that all columns are filled out with the correct data as expected.
* See that (very likely) a total of more than 0.00 libyears is calculated.
